### PR TITLE
Make GCP zone configurable in workflows

### DIFF
--- a/.github/workflows/shutdown.yml
+++ b/.github/workflows/shutdown.yml
@@ -2,6 +2,23 @@ name: Plex Shutdown
 
 on:
   workflow_dispatch:
+    inputs:
+      zone:
+        description: 'Google Cloud Zone'
+        required: true
+        default: 'us-east1-b'
+        type: choice
+        options:
+          - us-east1-b
+          - us-east1-c
+          - us-east1-d
+          - us-central1-a
+          - us-central1-b
+          - us-central1-c
+          - us-central1-f
+          - us-west1-a
+          - us-west1-b
+          - us-west1-c
 
 jobs:
   shutdown-plex:
@@ -21,7 +38,7 @@ jobs:
       - name: Define Variables
         id: vars
         run: |
-          echo "ZONE=us-east1-b" >> $GITHUB_ENV
+          echo "ZONE=${{ inputs.zone }}" >> $GITHUB_ENV
           echo "INIT_DATE=$(date +%Y%m%d-%H%M%S)" >> $GITHUB_ENV
           echo "SNAPSHOT_NAME=plex-snapshot-$(date +%Y%m%d-%H%M%S)" >> $GITHUB_ENV
           echo "PROJECT_ID=basic-lock-251300" >> $GITHUB_ENV

--- a/.github/workflows/startup.yml
+++ b/.github/workflows/startup.yml
@@ -2,6 +2,23 @@ name: Plex Startup
 
 on:
   workflow_dispatch:
+    inputs:
+      zone:
+        description: 'Google Cloud Zone'
+        required: true
+        default: 'us-east1-b'
+        type: choice
+        options:
+          - us-east1-b
+          - us-east1-c
+          - us-east1-d
+          - us-central1-a
+          - us-central1-b
+          - us-central1-c
+          - us-central1-f
+          - us-west1-a
+          - us-west1-b
+          - us-west1-c
 
 jobs:
   startup-plex:
@@ -21,7 +38,7 @@ jobs:
       - name: Define Variables
         id: vars
         run: |
-          echo "ZONE=us-east1-b" >> $GITHUB_ENV
+          echo "ZONE=${{ inputs.zone }}" >> $GITHUB_ENV
           echo "TEMPLATE=plex-template-1" >> $GITHUB_ENV
           echo "INIT_DATE=$(date +%Y%m%d-%H%M%S)" >> $GITHUB_ENV
           echo "DISK_NAME=plex-disk-$(date +%Y%m%d-%H%M%S)" >> $GITHUB_ENV


### PR DESCRIPTION
This PR updates the GitHub Actions workflows (`startup.yml` and `shutdown.yml`) to make the Google Cloud Platform (GCP) zone a configurable drop-down menu in the workflow UI. 

The `zone` input uses the `choice` type, offering a list of common GCP zones to select from. The default value is set to `us-east1-b`, ensuring backward compatibility with the previously hardcoded value. The `ZONE` environment variable in the workflow steps is now dynamically set using the selected input value (`${{ inputs.zone }}`).

---
*PR created automatically by Jules for task [6445858057931785590](https://jules.google.com/task/6445858057931785590) started by @josephrkramer*