### PR TITLE
Add missing US regions to GitHub workflows and update README

### DIFF
--- a/.github/workflows/shutdown.yml
+++ b/.github/workflows/shutdown.yml
@@ -12,13 +12,31 @@ on:
           - us-east1-b
           - us-east1-c
           - us-east1-d
+          - us-east4-a
+          - us-east4-b
+          - us-east4-c
+          - us-east5-a
+          - us-east5-b
+          - us-east5-c
           - us-central1-a
           - us-central1-b
           - us-central1-c
           - us-central1-f
+          - us-south1-a
+          - us-south1-b
+          - us-south1-c
           - us-west1-a
           - us-west1-b
           - us-west1-c
+          - us-west2-a
+          - us-west2-b
+          - us-west2-c
+          - us-west3-a
+          - us-west3-b
+          - us-west3-c
+          - us-west4-a
+          - us-west4-b
+          - us-west4-c
 
 jobs:
   shutdown-plex:

--- a/.github/workflows/startup.yml
+++ b/.github/workflows/startup.yml
@@ -12,13 +12,31 @@ on:
           - us-east1-b
           - us-east1-c
           - us-east1-d
+          - us-east4-a
+          - us-east4-b
+          - us-east4-c
+          - us-east5-a
+          - us-east5-b
+          - us-east5-c
           - us-central1-a
           - us-central1-b
           - us-central1-c
           - us-central1-f
+          - us-south1-a
+          - us-south1-b
+          - us-south1-c
           - us-west1-a
           - us-west1-b
           - us-west1-c
+          - us-west2-a
+          - us-west2-b
+          - us-west2-c
+          - us-west3-a
+          - us-west3-b
+          - us-west3-c
+          - us-west4-a
+          - us-west4-b
+          - us-west4-c
 
 jobs:
   startup-plex:

--- a/README.md
+++ b/README.md
@@ -34,6 +34,16 @@ To use these workflows, you need to configure the following:
     *   Create a new repository secret named `GCP_SA_KEY`. Paste the entire content of the JSON service account key file into this secret.
     *   (Optional but Recommended) Create another secret named `GCP_PROJECT_ID` and set its value to your Google Cloud Project ID. If you don't set this, the workflows will use the project ID hardcoded in the workflow files (`basic-lock-251300`), but using a secret is more flexible and secure. The workflows have been written to use the `GCP_PROJECT_ID` secret if available.
 
+### Choosing a Region and Zone
+
+When starting a Plex server, you will be prompted to select a Google Cloud Zone. You should choose a region and zone based on the following recommendations:
+
+*   **Latency:** Pick a region geographically closest to where you and your users will be streaming from to reduce network latency and improve streaming quality.
+*   **Cost:** Compute Engine instances and network egress costs vary between regions. Check the current pricing to find a cost-effective region.
+*   **Carbon Footprint:** Consider choosing a region with a lower carbon footprint if environmental impact is a priority.
+
+You can use the [Google Cloud Region Picker](https://cloud.withgoogle.com/region-picker/) tool to help evaluate and compare regions based on these criteria.
+
 ### Triggering the Workflows
 
 Both workflows are configured for manual triggering:


### PR DESCRIPTION
Added missing US regions to the startup and shutdown GitHub workflows. Also updated the README to include recommendations on choosing a region and zone, linking to the Google Cloud Region Picker.

---
*PR created automatically by Jules for task [13140543110735118586](https://jules.google.com/task/13140543110735118586) started by @josephrkramer*