### PR TITLE
Make gcloud settings configurable in workflows

### DIFF
--- a/.github/workflows/shutdown.yml
+++ b/.github/workflows/shutdown.yml
@@ -37,6 +37,11 @@ on:
           - us-west4-a
           - us-west4-b
           - us-west4-c
+      project_id:
+        description: 'Google Cloud Project ID'
+        required: true
+        default: 'basic-lock-251300'
+        type: string
 
 jobs:
   shutdown-plex:
@@ -59,7 +64,7 @@ jobs:
           echo "ZONE=${{ inputs.zone }}" >> $GITHUB_ENV
           echo "INIT_DATE=$(date +%Y%m%d-%H%M%S)" >> $GITHUB_ENV
           echo "SNAPSHOT_NAME=plex-snapshot-$(date +%Y%m%d-%H%M%S)" >> $GITHUB_ENV
-          echo "PROJECT_ID=basic-lock-251300" >> $GITHUB_ENV
+          echo "PROJECT_ID=${{ inputs.project_id }}" >> $GITHUB_ENV
 
       - name: Configure gcloud project
         run: gcloud config set project ${{ env.PROJECT_ID }}

--- a/.github/workflows/startup.yml
+++ b/.github/workflows/startup.yml
@@ -37,6 +37,16 @@ on:
           - us-west4-a
           - us-west4-b
           - us-west4-c
+      template:
+        description: 'Google Cloud Instance Template'
+        required: true
+        default: 'plex-template-1'
+        type: string
+      project_id:
+        description: 'Google Cloud Project ID'
+        required: true
+        default: 'basic-lock-251300'
+        type: string
 
 jobs:
   startup-plex:
@@ -57,11 +67,11 @@ jobs:
         id: vars
         run: |
           echo "ZONE=${{ inputs.zone }}" >> $GITHUB_ENV
-          echo "TEMPLATE=plex-template-1" >> $GITHUB_ENV
+          echo "TEMPLATE=${{ inputs.template }}" >> $GITHUB_ENV
           echo "INIT_DATE=$(date +%Y%m%d-%H%M%S)" >> $GITHUB_ENV
           echo "DISK_NAME=plex-disk-$(date +%Y%m%d-%H%M%S)" >> $GITHUB_ENV
           echo "SERVER_NAME=plex-server-$(date +%Y%m%d-%H%M%S)" >> $GITHUB_ENV
-          echo "PROJECT_ID=basic-lock-251300" >> $GITHUB_ENV
+          echo "PROJECT_ID=${{ inputs.project_id }}" >> $GITHUB_ENV
 
       - name: Configure gcloud project
         run: gcloud config set project ${{ env.PROJECT_ID }}


### PR DESCRIPTION
Added parameters to the Github Actions workflows to allow specifying the `project_id` and `template` (for the startup script). The current hardcoded values have been kept as defaults.

---
*PR created automatically by Jules for task [2914350208757518296](https://jules.google.com/task/2914350208757518296) started by @josephrkramer*