### PR TITLE
Update shutdown workflow to auto-detect zone

### DIFF
--- a/.github/workflows/shutdown.yml
+++ b/.github/workflows/shutdown.yml
@@ -3,40 +3,6 @@ name: Plex Shutdown
 on:
   workflow_dispatch:
     inputs:
-      zone:
-        description: 'Google Cloud Zone'
-        required: true
-        default: 'us-east1-b'
-        type: choice
-        options:
-          - us-east1-b
-          - us-east1-c
-          - us-east1-d
-          - us-east4-a
-          - us-east4-b
-          - us-east4-c
-          - us-east5-a
-          - us-east5-b
-          - us-east5-c
-          - us-central1-a
-          - us-central1-b
-          - us-central1-c
-          - us-central1-f
-          - us-south1-a
-          - us-south1-b
-          - us-south1-c
-          - us-west1-a
-          - us-west1-b
-          - us-west1-c
-          - us-west2-a
-          - us-west2-b
-          - us-west2-c
-          - us-west3-a
-          - us-west3-b
-          - us-west3-c
-          - us-west4-a
-          - us-west4-b
-          - us-west4-c
       project_id:
         description: 'Google Cloud Project ID'
         required: true
@@ -61,7 +27,6 @@ jobs:
       - name: Define Variables
         id: vars
         run: |
-          echo "ZONE=${{ inputs.zone }}" >> $GITHUB_ENV
           echo "INIT_DATE=$(date +%Y%m%d-%H%M%S)" >> $GITHUB_ENV
           echo "SNAPSHOT_NAME=plex-snapshot-$(date +%Y%m%d-%H%M%S)" >> $GITHUB_ENV
           echo "PROJECT_ID=${{ inputs.project_id }}" >> $GITHUB_ENV
@@ -72,13 +37,15 @@ jobs:
       - name: Get most recent VM instance
         id: vm_instance
         run: |
-          INSTANCE_INFO=$(gcloud compute instances list --project=${{ env.PROJECT_ID }} --format="value(name,creationTimestamp)" --sort-by=~creationTimestamp | head -n 1)
+          INSTANCE_INFO=$(gcloud compute instances list --project=${{ env.PROJECT_ID }} --format="value(name,zone,creationTimestamp)" --sort-by=~creationTimestamp | head -n 1)
           if [ -z "$INSTANCE_INFO" ]; then
             echo "No VM instance found. Exiting."
             exit 1
           fi
           MOST_RECENT_VM=$(echo $INSTANCE_INFO | awk '{print $1}')
+          MOST_RECENT_ZONE=$(echo $INSTANCE_INFO | awk '{print $2}')
           echo "MOST_RECENT_VM=$MOST_RECENT_VM" >> $GITHUB_ENV
+          echo "ZONE=$MOST_RECENT_ZONE" >> $GITHUB_ENV
           echo "::set-output name=vm_name::$MOST_RECENT_VM"
 
       - name: Stop the instance


### PR DESCRIPTION
Removed the `zone` input from the workflow dispatch inputs and modified the logic to dynamically determine the most recent VM instance's zone and save it as an environment variable to make the process completely automatic.

---
*PR created automatically by Jules for task [891427259360794370](https://jules.google.com/task/891427259360794370) started by @josephrkramer*