### PR TITLE
Refactor startup template to use a known good list of machine types

### DIFF
--- a/.github/workflows/startup.yml
+++ b/.github/workflows/startup.yml
@@ -41,7 +41,17 @@ on:
         description: 'Google Cloud Machine Type'
         required: true
         default: 'e2-standard-4'
-        type: string
+        type: choice
+        options:
+          - e2-micro
+          - e2-small
+          - e2-medium
+          - e2-standard-2
+          - e2-standard-4
+          - e2-standard-8
+          - n2-standard-2
+          - n2-standard-4
+          - n2-standard-8
       disk_type:
         description: 'Google Cloud Disk Type'
         required: true


### PR DESCRIPTION
Refactored the `machine_type` input in the `.github/workflows/startup.yml` workflow to use a `choice` type rather than a `string` type, making it easier to select a known good Google Cloud machine type. Included a number of standard choices like `e2-micro`, `e2-standard-4` (the default), `n2-standard-4`, etc.

---
*PR created automatically by Jules for task [15031870214310827367](https://jules.google.com/task/15031870214310827367) started by @josephrkramer*