### PR TITLE
Update Plex installation script repository setup

### DIFF
--- a/install-plex.sh
+++ b/install-plex.sh
@@ -1,10 +1,21 @@
 #!/bin/bash
 
-sudo apt install curl
-curl https://downloads.plex.tv/plex-keys/PlexSign.key | sudo apt-key add -
-
-echo deb https://downloads.plex.tv/repo/deb public main | sudo tee /etc/apt/sources.list.d/plexmediaserver.list
-
-sudo apt install apt-transport-https
+# Remove Old Repository
+sudo rm -fv /etc/apt/sources.list.d/plex*
 sudo apt update
-sudo apt install plexmediaserver
+sudo apt upgrade -y
+
+# Setup New Repository
+# Make sure that curl and gnupg2 are installed
+sudo apt update
+sudo apt install -y curl gnupg2 apt-transport-https
+
+# Add the new Plex GPG key
+curl -L https://downloads.plex.tv/plex-keys/PlexSign.v2.key | sudo gpg --yes --dearmor -o /etc/apt/keyrings/plexmediaserver.v2.gpg
+
+# Add the new repository to sources.list.d
+echo "deb [signed-by=/etc/apt/keyrings/plexmediaserver.v2.gpg] https://repo.plex.tv/deb/ public main" | sudo tee /etc/apt/sources.list.d/plex.list
+
+# Install Plex Media Server
+sudo apt update
+sudo apt install -y plexmediaserver

--- a/install-plex.sh
+++ b/install-plex.sh
@@ -11,6 +11,7 @@ sudo apt update
 sudo apt install -y curl gnupg2 apt-transport-https
 
 # Add the new Plex GPG key
+sudo mkdir -p -m 755 /etc/apt/keyrings
 curl -L https://downloads.plex.tv/plex-keys/PlexSign.v2.key | sudo gpg --yes --dearmor -o /etc/apt/keyrings/plexmediaserver.v2.gpg
 
 # Add the new repository to sources.list.d


### PR DESCRIPTION
Updated `install-plex.sh` to follow the latest instructions from the Plex website for Debian-based distributions. The script now correctly uses the v2 GPG key, `/etc/apt/keyrings`, and includes the step to remove the old repository file.

---
*PR created automatically by Jules for task [9832365139798958141](https://jules.google.com/task/9832365139798958141) started by @josephrkramer*